### PR TITLE
Devise token auth

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,8 +10,9 @@ gem "rails", "~> 7.0.4", ">= 7.0.4.2"
 gem "sprockets-rails"
 
 gem "devise"
-
+gem 'devise_token_auth'
 gem 'devise-i18n'
+gem 'omniauth', '>= 1.0.0'
 
 gem 'delayed_job_active_record'
 

--- a/Gemfile
+++ b/Gemfile
@@ -57,6 +57,8 @@ gem "sassc-rails"
 
 gem "faker", "2.21.0"
 
+gem 'rack-cors'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debase"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,6 +107,10 @@ GEM
       warden (~> 1.2.3)
     devise-i18n (1.10.3)
       devise (>= 4.8.0)
+    devise_token_auth (1.2.2)
+      bcrypt (~> 3.0)
+      devise (> 3.5.2, < 5)
+      rails (>= 4.2.0, < 7.1)
     diff-lcs (1.5.0)
     dockerfile-rails (1.2.1)
       rails
@@ -121,6 +125,7 @@ GEM
     ffi (1.15.5)
     globalid (1.1.0)
       activesupport (>= 5.0)
+    hashie (5.0.0)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     importmap-rails (1.1.5)
@@ -179,6 +184,10 @@ GEM
       racc (~> 1.4)
     nokogiri (1.14.1-x86_64-linux)
       racc (~> 1.4)
+    omniauth (2.1.1)
+      hashie (>= 3.4.6)
+      rack (>= 2.2.3)
+      rack-protection
     orm_adapter (0.5.0)
     parallel (1.22.1)
     parser (3.2.1.0)
@@ -191,6 +200,8 @@ GEM
     rack (2.2.6.2)
     rack-cors (2.0.1)
       rack (>= 2.0.0)
+    rack-protection (3.1.0)
+      rack (~> 2.2, >= 2.2.4)
     rack-test (2.0.2)
       rack (>= 1.3)
     rails (7.0.4.2)
@@ -333,12 +344,14 @@ DEPENDENCIES
   delayed_job_active_record
   devise
   devise-i18n
+  devise_token_auth
   dockerfile-rails (>= 1.2)
   faker (= 2.21.0)
   faraday
   importmap-rails
   jbuilder
   letter_opener_web
+  omniauth (>= 1.0.0)
   pg
   puma (~> 5.0)
   rack-cors

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -189,6 +189,8 @@ GEM
       nio4r (~> 2.0)
     racc (1.6.2)
     rack (2.2.6.2)
+    rack-cors (2.0.1)
+      rack (>= 2.0.0)
     rack-test (2.0.2)
       rack (>= 1.3)
     rails (7.0.4.2)
@@ -339,6 +341,7 @@ DEPENDENCIES
   letter_opener_web
   pg
   puma (~> 5.0)
+  rack-cors
   rails (~> 7.0.4, >= 7.0.4.2)
   rbs (~> 2.8.4)
   rbs_rails

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,4 @@
-class ApplicationController < ActionController::Base
+class ApplicationController < ActionController::API
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   protected

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::API
+  include DeviseTokenAuth::Concerns::SetUserByToken
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   protected

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -3,7 +3,8 @@ class BooksController < ApplicationController
   before_action :redirect_to_sign_in, only: %i[show], unless: :user_signed_in?
 
   def index
-    @books = Book.eager_load(:reservation_active, :lend_active).with_attached_image.order(:id)
+    books = Book.eager_load(:reservation_active, :lend_active).with_attached_image.order(:id)
+    render json: books
   end
 
   def show
@@ -13,6 +14,10 @@ class BooksController < ApplicationController
     reservation = @book.reservations.where("reservation_at >= ?", Time.now).where(user_id: current_user.id).first
     redirect_to reservation_path(reservation) if reservation
     @reservations = @book.reservations.where("reservation_at >= ?", Time.now).order(reservation_at: :asc)
+    render json: {
+      "book" => @book,
+      "reservations" => @reservations
+    }
   end
 
   private

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -8,7 +8,7 @@ class Book < ApplicationRecord
 
   validates :title, presence: true
 
-  delegate :created_at, :return_at, :user, to: :lending
+  delegate :created_at, :return_at, :user, to: :lending, allow_nil: true
 
   def status(user)
     user_id = user&.id

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,9 @@
 class User < ApplicationRecord
-  devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable
+# Include default devise modules.
+devise :database_authenticatable, :registerable,
+        :recoverable, :rememberable, :validatable, :omniauthable
+include DeviseTokenAuth::Concerns::User
+
   enum :role, [:admin, :user]
 
   has_many :lendings, dependent: :destroy

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,6 +8,7 @@ Bundler.require(*Rails.groups)
 
 module Workspace
   class Application < Rails::Application
+    config.api_only = true
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.0
     config.time_zone = "Tokyo"
@@ -16,6 +17,15 @@ module Workspace
 
     config.active_job.queue_adapter = :delayed_job
     config.autoload_paths << "#{Rails.root}/lib"
+
+    config.middleware.insert_before 0, Rack::Cors do
+      allow do
+        origins ENV["FRONTEND_ORIGIN"]
+        resource "*",
+                 headers: :any,
+                 methods: [:get, :post, :patch, :delete, :options, :head]
+      end
+    end
 
     # Configuration for the application, engines, and railties goes here.
     #

--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+DeviseTokenAuth.setup do |config|
+  # By default the authorization headers will change after each request. The
+  # client is responsible for keeping track of the changing tokens. Change
+  # this to false to prevent the Authorization header from changing after
+  # each request.
+  config.change_headers_on_each_request = false
+
+  # By default, users will need to re-authenticate after 2 weeks. This setting
+  # determines how long tokens will remain valid after they are issued.
+  config.token_lifespan = 2.weeks
+
+  # Limiting the token_cost to just 4 in testing will increase the performance of
+  # your test suite dramatically. The possible cost value is within range from 4
+  # to 31. It is recommended to not use a value more than 10 in other environments.
+  config.token_cost = Rails.env.test? ? 4 : 10
+
+  # Sets the max number of concurrent devices per user, which is 10 by default.
+  # After this limit is reached, the oldest tokens will be removed.
+  # config.max_number_of_devices = 10
+
+  # Sometimes it's necessary to make several requests to the API at the same
+  # time. In this case, each request in the batch will need to share the same
+  # auth token. This setting determines how far apart the requests can be while
+  # still using the same auth token.
+  # config.batch_request_buffer_throttle = 5.seconds
+
+  # This route will be the prefix for all oauth2 redirect callbacks. For
+  # example, using the default '/omniauth', the github oauth2 provider will
+  # redirect successful authentications to '/omniauth/github/callback'
+  # config.omniauth_prefix = "/omniauth"
+
+  # By default sending current password is not needed for the password update.
+  # Uncomment to enforce current_password param to be checked before all
+  # attribute updates. Set it to :password if you want it to be checked only if
+  # password is updated.
+  # config.check_current_password_before_update = :attributes
+
+  # By default we will use callbacks for single omniauth.
+  # It depends on fields like email, provider and uid.
+  # config.default_callbacks = true
+
+  # Makes it possible to change the headers names
+  config.headers_names = {
+    :'authorization' => 'Authorization',
+    :'access-token' => 'access-token',
+    :'client' => 'client',
+    :'expiry' => 'expiry',
+    :'uid' => 'uid',
+    :'token-type' => 'token-type'
+  }
+
+  # Makes it possible to use custom uid column
+  # config.other_uid = "foo"
+
+  # By default, only Bearer Token authentication is implemented out of the box.
+  # If, however, you wish to integrate with legacy Devise authentication, you can
+  # do so by enabling this flag. NOTE: This feature is highly experimental!
+  # config.enable_standard_devise_support = false
+
+  # By default DeviseTokenAuth will not send confirmation email, even when including
+  # devise confirmable module. If you want to use devise confirmable module and
+  # send email, set it to true. (This is a setting for compatibility)
+  # config.send_confirmation_email = true
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,17 @@
 Rails.application.routes.draw do
+  # mount_devise_token_auth_for 'User', at: 'auth'
   devise_for :users, controllers: {
     registrations: "users/registrations",
     sessions: "users/sessions"
   }
+  namespace :api, fomat: :json do
+    scope :v1 do
+      mount_devise_token_auth_for 'User', at: 'auth', controllers: {
+        registrations: "devise_token_auth/registrations",
+        sessions: "devise_token_auth/sessions"
+      }
+    end
+  end
   root "top#index"
   namespace :admin do
     resources :books, only: [:index, :new, :create] do

--- a/db/migrate/20231123061223_devise_token_auth_create_users.rb
+++ b/db/migrate/20231123061223_devise_token_auth_create_users.rb
@@ -1,0 +1,13 @@
+class DeviseTokenAuthCreateUsers < ActiveRecord::Migration[7.0]
+  def up
+    add_column :users, :provider, :string, null: false, default: 'email'
+    add_column :users, :uid, :string, null: false, default: ''
+    add_column :users, :tokens, :text
+  end
+
+  def down
+    # if you added **encrypted_password** above, add here to successfully rollback
+    remove_columns :users, :provider, :uid, :tokens
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_17_065711) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_23_061223) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -109,6 +109,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_17_065711) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "provider", default: "email", null: false
+    t.string "uid", default: "", null: false
+    t.text "tokens"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: "3"
 
 services:
   app:
@@ -16,7 +16,7 @@ services:
       - postgres
     command: bash -c 'rm -f ./tmp/pids/server.pid && bin/rails s -b 0.0.0.0'
     environment:
-      - TZ=Asia/Tokyo
+      FRONTEND_ORIGIN: http://localhost:3001
     stdin_open: true
     tty: true
   postgres:


### PR DESCRIPTION
devise_token_authの導入
以下のルーティングはできることを確認しました。 
- get /books
- post /api/v1/auth/ (ユーザー新規登録)
- post /api/v1/auth/sing_in (ログイン)